### PR TITLE
Update mlnxlogin

### DIFF
--- a/mlnxlogin
+++ b/mlnxlogin
@@ -642,11 +642,10 @@ proc run_commands { prompt command } {
 	}
 	# match cisco config mode prompts too, such as router(config-if)#,
 	# but catalyst does not change in this fashion.
-	regsub -all {^(.{1,11}).*([#>])$} $prompt {\1([^#>\r\n]+)?[#>](\\([^)\\r\\n]+\\))?} reprompt
-	expect {
-	    -re $reprompt	{}
-	    -re "\[\n\r]+"	{ exp_continue }
-	}
+        regsub -lineanchor -- {^(.{1,11}).*([#>])$} $prompt {\1} reprompt
+        regsub -all -- {[\\]$} $reprompt {} reprompt
+        append reprompt {([^#>\r\n]+)?[#>](\\([^)\\r\\n]+\\))?}
+	
     } else {
 	set reprompt $prompt
     }


### PR DESCRIPTION
Updated this bit, I don't really know what it does, I'm not much of a programmer.

Was getting a "couldn't compile regular expression pattern: parentheses () not balanced" error.  Googled around a bit and saw people talking about different versions of tcl etc..., so I thought maybe my linux/rancid environment had newer dependencies or something.

Realizing that it's a bastardized clogin script, I went to the current version of clogin in my RANCID install, and found the corresponding bits and swapped them out and it worked. /shrug